### PR TITLE
MOEN-45080: Retry pod install on CocoaPods CDN propagation lag

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,36 @@ EXAMPLES = 'Examples'
 LOCK = File.join(EXAMPLES, 'Podfile.lock')
 TUIST = File.join(`brew --prefix`.strip, 'bin', 'tuist')
 
+# Retries `pod install --repo-update` on CocoaPods CDN propagation lag —
+# observed when chained partner releases run before the freshly-pushed
+# native pod is visible in the CDN index. Only retries on spec-resolution
+# failures; any other failure bubbles up immediately.
+def pod_install_with_retry(max_attempts: 5, initial_delay: 30)
+  attempt = 0
+  delay = initial_delay
+  loop do
+    attempt += 1
+    output = +''
+    IO.popen('pod install --repo-update 2>&1', 'r') do |io|
+      io.each_line do |line|
+        print line
+        output << line
+      end
+    end
+    status = $?
+    return if status.success?
+
+    cdn_lag = output.include?('could not find compatible versions')
+    if cdn_lag && attempt < max_attempts
+      puts "[Rakefile] pod install failed — likely CocoaPods CDN propagation lag (attempt #{attempt}/#{max_attempts}). Retrying in #{delay}s..."
+      sleep delay
+      delay = [delay * 2, 480].min
+    else
+      raise "pod install --repo-update failed (exit #{status.exitstatus})"
+    end
+  end
+end
+
 file TUIST do
   system('brew install tuist', out: STDOUT, exception: true)
 end
@@ -22,7 +52,7 @@ end
 
 file LOCK => [config.xcframework.workspace] do
   Dir.chdir(EXAMPLES) do
-    system('pod install --repo-update', out: STDOUT, exception: true)
+    pod_install_with_retry
   end
 end
 
@@ -38,7 +68,7 @@ task :setup => [TUIST] do |t|
     pod_lock_file = 'Podfile.lock'
     FileUtils.rm(pod_lock_file) if File.exist?(pod_lock_file)
     system('tuist generate --no-open', out: STDOUT, exception: true)
-    system('pod install --repo-update', out: STDOUT, exception: true)
+    pod_install_with_retry
   end
 end
 


### PR DESCRIPTION
## Summary

- Wraps `pod install --repo-update` in a retry-with-backoff helper to absorb CocoaPods CDN propagation lag during chained partner releases.
- Retries only when the failure matches a spec-resolution miss (`could not find compatible versions`); any other failure bubbles up immediately so genuine config/build errors still fail fast.
- Backoff: 30s → 60s → 120s → 240s → 480s (cap), 5 attempts max — total wait window ~15 min.

## Why

The mParticle release workflow (`cd.yml`) is the only chained partner that runs a post-publish `pod install --repo-update` against the freshly-pushed native `MoEngage-iOS-SDK` pod. CocoaPods' CDN takes a variable amount of time to index a newly-pushed spec, so this step can fail with the resolution miss above even though the native pod is in fact on trunk.

The result is a partial release: the mParticle pod is published, the git tag is created, but the GitHub release is never created and Slack is never notified — requiring manual recovery.

History (last 10 mParticle `cd.yml` runs): **5 success / 5 failure**, including a 4-failures-then-1-success cluster on 2026-01-22 and the most recent failure during the REL-3427 release (2026-05-25). Segment, which has no equivalent post-publish pod-install step, is 9/10 successful over the same window.

Ticket: [MOEN-45080](https://moengagetrial.atlassian.net/browse/MOEN-45080)

## Test plan

- [ ] Local: `rake setup` still succeeds on a clean checkout (no behavior change when CDN is healthy).
- [ ] Local: `ruby -c Rakefile` passes syntax check (verified).
- [ ] Next mParticle release: confirm chained partner job completes end-to-end without manual `gh release create` follow-up.
- [ ] If a retry occurs in CI, confirm the `[Rakefile] pod install failed — likely CocoaPods CDN propagation lag` log line is emitted with attempt counter.

## Follow-up

If other partner repos (Segment, PluginBase, Cards/Geofence/Inbox/Personalize) start showing the same flake, lift this helper into `moengage/sdk-automation-scripts` so the retry applies uniformly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MOEN-45080]: https://moengagetrial.atlassian.net/browse/MOEN-45080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ