### PR TITLE
MOEN-45080 + MOEN-45310: Fix mParticle release pod-install flake and SPM CI test crash

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,36 @@ EXAMPLES = 'Examples'
 LOCK = File.join(EXAMPLES, 'Podfile.lock')
 TUIST = File.join(`brew --prefix`.strip, 'bin', 'tuist')
 
+# Retries `pod install --repo-update` on CocoaPods CDN propagation lag —
+# observed when chained partner releases run before the freshly-pushed
+# native pod is visible in the CDN index. Only retries on spec-resolution
+# failures; any other failure bubbles up immediately.
+def pod_install_with_retry(max_attempts: 5, initial_delay: 30)
+  attempt = 0
+  delay = initial_delay
+  loop do
+    attempt += 1
+    output = +''
+    IO.popen('pod install --repo-update 2>&1', 'r') do |io|
+      io.each_line do |line|
+        print line
+        output << line
+      end
+    end
+    status = $?
+    return if status.success?
+
+    cdn_lag = output.include?('could not find compatible versions')
+    if cdn_lag && attempt < max_attempts
+      puts "[Rakefile] pod install failed — likely CocoaPods CDN propagation lag (attempt #{attempt}/#{max_attempts}). Retrying in #{delay}s..."
+      sleep delay
+      delay = [delay * 2, 480].min
+    else
+      raise "pod install --repo-update failed (exit #{status.exitstatus})"
+    end
+  end
+end
+
 file TUIST do
   system('brew install tuist', out: STDOUT, exception: true)
 end
@@ -22,7 +52,7 @@ end
 
 file LOCK => [config.xcframework.workspace] do
   Dir.chdir(EXAMPLES) do
-    system('pod install --repo-update', out: STDOUT, exception: true)
+    pod_install_with_retry
   end
 end
 
@@ -38,7 +68,7 @@ task :setup => [TUIST] do |t|
     pod_lock_file = 'Podfile.lock'
     FileUtils.rm(pod_lock_file) if File.exist?(pod_lock_file)
     system('tuist generate --no-open', out: STDOUT, exception: true)
-    system('pod install --repo-update', out: STDOUT, exception: true)
+    pod_install_with_retry
   end
 end
 

--- a/Tests/mParticle-MoEngageTests/mParticle_MoEngageTests.swift
+++ b/Tests/mParticle-MoEngageTests/mParticle_MoEngageTests.swift
@@ -66,6 +66,11 @@ final class mParticle_MoEngageTests {
         }
     }
 
+    // SPM cannot host an app; UNUserNotificationCenter.current() asserts on
+    // bundleProxyForCurrentProcess from Xcode 26 onward. Sibling to MOEN-42758,
+    // which fixed the equivalent crash for the CocoaPods scheme via
+    // requires_app_host = true. Tests below run only under the CocoaPods scheme.
+    #if !SWIFT_PACKAGE
     @Test(.enabled(if: UIDevice.current.userInterfaceIdiom != .tv))
     func iOSValidConfig() async throws {
         let kit = MPKitMoEngage()
@@ -189,6 +194,7 @@ final class mParticle_MoEngageTests {
             #expect(result.integrationId == MPKitMoEngageConstant.kitCode as NSNumber, sourceLocation: sourceLocation)
         }
     }
+    #endif
 
     @Test(.enabled(if: UIDevice.current.userInterfaceIdiom == .tv))
     func tvOSEmptyConfig() throws {


### PR DESCRIPTION
Combined PR for two CI-blocking fixes surfaced during the REL-3427 release cycle. Both jobs go green together; reviewing them as one keeps the history coherent.

## Fix 1 — [MOEN-45080](https://moengagetrial.atlassian.net/browse/MOEN-45080): Retry pod install on CocoaPods CDN propagation lag (commit [a8a67ea](https://github.com/moengage/mparticle-apple-integration-moengage/commit/a8a67ea))

Wraps `pod install --repo-update` in a retry-with-backoff helper. Retries only when the failure matches a CocoaPods spec-resolution miss (`could not find compatible versions`); any other failure bubbles up immediately so genuine config/build errors still fail fast. Backoff: 30s → 60s → 120s → 240s → 480s (cap), 5 attempts max, total wait window ~15 min.

**Why:** mParticle's chained-partner release flow runs a post-publish `pod install --repo-update` against the freshly-pushed native `MoEngage-iOS-SDK` pod. CocoaPods' CDN takes a variable amount of time to index a newly-pushed spec, so this step can fail with the resolution miss above even though the native pod is in fact on trunk — the result is a partial release: pod on trunk, git tag created, but no GitHub release and no Slack notification.

History (last 10 `cd.yml` runs): **5 success / 5 failure**, including a 4-failures-then-1-success cluster on 2026-01-22 and the most recent failure during the REL-3427 release (2026-05-25). Segment, which has no equivalent post-publish pod-install step, is 9/10 successful over the same window.

## Fix 2 — [MOEN-45310](https://moengagetrial.atlassian.net/browse/MOEN-45310): Guard host-requiring SPM tests behind SWIFT_PACKAGE (commit [fc69863](https://github.com/moengage/mparticle-apple-integration-moengage/commit/fc69863))

Wraps `iOSValidConfig` and `iOSValidTestConfig` in `#if !SWIFT_PACKAGE`. These two tests initialize MoEngage with a valid config and then call `kit.handleAction(withIdentifier:forRemoteNotification:)` → `MoEngageMessaging` → `UNUserNotificationCenter.current()` — Apple's `bundleProxyForCurrentProcess` assertion is stricter under Xcode 26, so this crashes when the test runs under the SPM `xctest` agent (no app host).

**Why:** Sibling fix to [MOEN-42758](https://moengagetrial.atlassian.net/browse/MOEN-42758) ([`cf81c5c`](https://github.com/moengage/mparticle-apple-integration-moengage/commit/cf81c5c)), which fixed the same crash for the CocoaPods scheme via `requires_app_host = true` in the test_spec. SPM has no analogous directive, so excluding the two host-requiring tests is the surgical fix. The CocoaPods scheme continues to run all 8 iOS tests; SPM runs 6.

Timeline confirming the SPM breakage is pre-existing, not caused by this PR:

| Date | Event |
|---|---|
| 2025-09-24 | Last green SPM CI on this repo (Xcode 16.4) |
| 2025-12-01 | `sdk-automation-scripts` bumped Xcode to 26.1.1 (MOEN-41798) |
| 2026-01-21 | CocoaPods app-host fix added (MOEN-42758); SPM not addressed |
| Dec 2025 → May 2026 | No PR completes full CI; breakage latent |
| 2026-05-29 | First post-bump PR completes CI; SPM crash surfaces |

## Test plan

- [x] Local: `ruby -c Rakefile` syntax check passes
- [ ] CI: CocoaPods job runs all 8 iOS tests + tvOS subscheme green
- [ ] CI: SPM job runs 6 iOS tests green (down from 8 — the 2 excluded tests are fully covered by the CocoaPods scheme)
- [ ] Next mParticle release: confirm chained partner job completes end-to-end without manual `gh release create` follow-up; if a retry occurs, confirm the `[Rakefile] pod install failed — likely CocoaPods CDN propagation lag` log line is emitted

## Out of scope / follow-ups

- Lift the `pod_install_with_retry` helper into `moengage/sdk-automation-scripts` if other partner repos (Segment, PluginBase, plugins) start showing the same flake
- Refactor `MoEngageMessaging` to inject `UNUserNotificationCenter` via a protocol so host-required code can be unit-tested under SPM (proper long-term SDK fix; cross-repo scope)

Closes #16 (superseded — combined here for single-review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MOEN-45080]: https://moengagetrial.atlassian.net/browse/MOEN-45080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOEN-45310]: https://moengagetrial.atlassian.net/browse/MOEN-45310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ