### PR TITLE
MOEN-45310: Guard host-requiring SPM tests behind SWIFT_PACKAGE

### DIFF
--- a/Tests/mParticle-MoEngageTests/mParticle_MoEngageTests.swift
+++ b/Tests/mParticle-MoEngageTests/mParticle_MoEngageTests.swift
@@ -66,6 +66,11 @@ final class mParticle_MoEngageTests {
         }
     }
 
+    // SPM cannot host an app; UNUserNotificationCenter.current() asserts on
+    // bundleProxyForCurrentProcess from Xcode 26 onward. Sibling to MOEN-42758,
+    // which fixed the equivalent crash for the CocoaPods scheme via
+    // requires_app_host = true. Tests below run only under the CocoaPods scheme.
+    #if !SWIFT_PACKAGE
     @Test(.enabled(if: UIDevice.current.userInterfaceIdiom != .tv))
     func iOSValidConfig() async throws {
         let kit = MPKitMoEngage()
@@ -189,6 +194,7 @@ final class mParticle_MoEngageTests {
             #expect(result.integrationId == MPKitMoEngageConstant.kitCode as NSNumber, sourceLocation: sourceLocation)
         }
     }
+    #endif
 
     @Test(.enabled(if: UIDevice.current.userInterfaceIdiom == .tv))
     func tvOSEmptyConfig() throws {


### PR DESCRIPTION
## Summary

Wraps two tests that require an app-host (`iOSValidConfig`, `iOSValidTestConfig`) in `#if !SWIFT_PACKAGE` so the SPM scheme excludes them. The CocoaPods scheme is unaffected — it continues to run all tests with a real app host via `requires_app_host = true` (added in [`cf81c5c`](https://github.com/moengage/mparticle-apple-integration-moengage/commit/cf81c5c) / [MOEN-42758](https://moengagetrial.atlassian.net/browse/MOEN-42758)).

Diff: 6 lines added, nothing else changed. Production code untouched.

## Why

The `Build and run tests for Swift Package Manager` CI job has been failing deterministically on every PR since the runner Xcode bumped to 26.1.1 in `sdk-automation-scripts` (MOEN-41798, 2025-12-01). The crash:

```
*** Assertion failure in +[UNUserNotificationCenter currentNotificationCenter]
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException',
    reason: 'bundleProxyForCurrentProcess is nil:
    mainBundle.bundleURL file:///Applications/Xcode_26.1.1.app/.../iPhoneSimulator.platform/.../Agents/'
```

Stack trace shows `kit.handleAction(withIdentifier:forRemoteNotification:)` → mParticle Kit → `MoEngageMessaging` → `UNUserNotificationCenter.current()`. Xcode 26 tightened the `bundleProxyForCurrentProcess` assertion in this API. The SPM `xctest` agent is not a real app bundle, so the assertion fires and the test process terminates.

CocoaPods handles this via the podspec's `requires_app_host = true`, which generates an app target host for the test bundle. SPM has no equivalent directive — `Package.swift` cannot declare a test host. Apple's documented workaround is to exclude such tests from the SPM scheme. This PR does exactly that.

Timeline that confirms this is pre-existing, not caused by recent changes:

| Date | Event |
|---|---|
| 2025-09-24 | Last green SPM CI on this repo (Xcode 16.4) |
| 2025-12-01 | Xcode bumped to 26.1.1 in shared `ios-action-setup` action |
| 2026-01-21 | CocoaPods app-host fix added (MOEN-42758); SPM not addressed |
| Dec 2025 → May 2026 | No PR completes a full CI run; breakage latent |
| 2026-05-29 | First PR ([#14](https://github.com/moengage/mparticle-apple-integration-moengage/pull/14) / [#15](https://github.com/moengage/mparticle-apple-integration-moengage/pull/15)) since the bump completes CI; SPM job surfaces the crash |

## Coverage impact

SPM scheme runs 6 iOS tests instead of 8. The 2 skipped tests (`iOSValidConfig`, `iOSValidTestConfig`) are fully covered by the CocoaPods scheme — same production code, same kit method calls, with a real app host. No net coverage loss.

## Test plan

- [ ] CI: `Build and run tests for CocoaPods` ✅ (continues to run all tests including the two guarded ones)
- [ ] CI: `Build and run tests for Swift Package Manager` ✅ (now runs the 6 remaining tests without crashing)
- [ ] Local: `xcodebuild test -scheme mParticle-MoEngage` resolves the SPM package, builds, and exits 0
- [ ] Local: `rake test:pods` inside `Examples/` still runs all 8 iOS tests

## Out of scope / follow-ups

- Refactoring `MoEngageMessaging` to inject `UNUserNotificationCenter` via a protocol so host-required code can be properly unit-tested under SPM — proper long-term fix, cross-repo SDK work
- Considering whether the SPM test job should be dropped from CI entirely (defensible given CocoaPods covers the same code paths) — leaving in for now, since it still catches SPM-specific build issues (`Package.swift` drift, conditional compilation slipups)

Ticket: [MOEN-45310](https://moengagetrial.atlassian.net/browse/MOEN-45310)
Sibling fix: [MOEN-42758](https://moengagetrial.atlassian.net/browse/MOEN-42758) ([`cf81c5c`](https://github.com/moengage/mparticle-apple-integration-moengage/commit/cf81c5c))
Surfaced by: [PR #15](https://github.com/moengage/mparticle-apple-integration-moengage/pull/15) (MOEN-45080)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MOEN-42758]: https://moengagetrial.atlassian.net/browse/MOEN-42758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOEN-45310]: https://moengagetrial.atlassian.net/browse/MOEN-45310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ